### PR TITLE
Drop permissions

### DIFF
--- a/.github/workflows/jenkins-security-scan.yaml
+++ b/.github/workflows/jenkins-security-scan.yaml
@@ -12,6 +12,13 @@ on:
         type: string
         required: false
 
+permissions:
+  security-events: write
+
+  # Private repo support
+  contents: read # For actions/checkout
+  actions: read # For github/codeql-action/upload-sarif
+
 jobs:
   scan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolves #4.

Tested on a public repo main branch, a public PR from fork, and a private repo's main branch.

Interestingly, `security-events: write` is needed even though the action works from forks. My best guess is that there's a different code path involved on forks, or perhaps PRs in general.