### PR TITLE
Update CodeQL CLI to v2.9.0

### DIFF
--- a/.github/workflows/jenkins-security-scan.yaml
+++ b/.github/workflows/jenkins-security-scan.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Install CodeQL CLI
         uses: jenkins-infra/fetch-codeql-action@v1
         with:
-          version: v2.8.1
+          version: v2.9.0
       - name: Install jq
         run: |
           sudo apt-get update


### PR DESCRIPTION
Adapt to https://github.com/jenkins-infra/jenkins-codeql/pull/16

(Upstream merge probably needs immediate corresponding `v2` tag update here.)