### PR TITLE
Update codeql-action to v2

### DIFF
--- a/.github/workflows/jenkins-security-scan.yaml
+++ b/.github/workflows/jenkins-security-scan.yaml
@@ -73,7 +73,7 @@ jobs:
           path: jenkins-security-scan.sarif
           name: Jenkins Security Scan SARIF
       - name: Upload Scan Result
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: jenkins-security-scan.sarif
           category: Jenkins Security Scan


### PR DESCRIPTION
Update to `v2` as `v1` will be deprecated in December 2022.

closes #9 