### PR TITLE
Update CodeQL to 2.13.4

### DIFF
--- a/.github/workflows/jenkins-security-scan.yaml
+++ b/.github/workflows/jenkins-security-scan.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install CodeQL CLI
         uses: jenkins-infra/fetch-codeql-action@v1
         with:
-          version: v2.12.2 # Keep version of codeql/java-queries in sync: https://github.com/github/codeql/blob/main/java/ql/src/CHANGELOG.md
+          version: v2.13.4 # Keep version of codeql/java-queries in sync: https://github.com/github/codeql/blob/main/java/ql/src/CHANGELOG.md
       - name: Install jq
         run: |
           sudo apt-get update
@@ -56,7 +56,7 @@ jobs:
           set -o pipefail
 
           codeql pack install "$CODEQL_RULES_DIR/src/"
-          codeql pack download codeql/java-queries@0.5.2
+          codeql pack download codeql/java-queries@0.6.3
 
           echo "::group::Create Database"
           LGTM_INDEX_XML_MODE=all codeql database create --language=java --source-root="$CHECKOUT_DIR" "$GITHUB_WORKSPACE/database" || { echo "Failed to create database" >&2 ; exit 1 ; }


### PR DESCRIPTION
In conjunction with https://github.com/jenkins-infra/jenkins-codeql/pull/28

The versions defined don't support Java versions beyond 19 plus the binary fails due to outdated ASM not supporting newer Java versions.
Support for JDK 20 comes with 0.5.4, yet I updated them to newer versions, preventing further updates.

The change proposed mitigates both limitations.