### PR TITLE
Make Java version an optional parameter

### DIFF
--- a/.github/workflows/jenkins-security-scan.yaml
+++ b/.github/workflows/jenkins-security-scan.yaml
@@ -6,7 +6,7 @@ on:
       java-version:
         description: Version of Java set up for the build. See actions/setup-java documentation for values.
         type: string
-        required: true
+        required: false
       java-cache:
         description: What kind of Java dependency cache to set up. See actions/setup-java documentation for values.
         type: string
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: ${{ inputs.java-version }}
+          java-version: ${{ inputs.java-version || '17' }}
           cache: ${{ inputs.java-cache }}
 
       - name: Initialize CodeQL


### PR DESCRIPTION
Resolves #29 by making the `java-version` input optional, all truthy values are used as is, all falsy values are replaced by a default (here 17 to align with https://github.com/jenkins-infra/github-reusable-workflows/pull/31).