### PR TITLE
Install a specific version of Maven

### DIFF
--- a/.github/workflows/jenkins-security-scan.yaml
+++ b/.github/workflows/jenkins-security-scan.yaml
@@ -33,6 +33,22 @@ jobs:
           java-version: ${{ inputs.java-version || '17' }}
           cache: ${{ inputs.java-cache }}
 
+      # https://github.com/jenkins-infra/github-reusable-workflows/issues/36
+      - name: Set up Maven
+        run: |
+          wget --no-verbose https://downloads.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz
+          echo $CHECKSUM apache-maven-$MAVEN_VERSION-bin.tar.gz | sha512sum --check
+          tar xzf apache-maven-$MAVEN_VERSION-bin.tar.gz
+          rm apache-maven-$MAVEN_VERSION-bin.tar.gz
+          sudo mv apache-maven-$MAVEN_VERSION /opt/maven
+          sudo rm -f /usr/bin/mvn
+          sudo ln -s /opt/maven/bin/mvn /usr/bin/mvn
+          mvn --version
+        env:
+          MAVEN_VERSION: 3.9.9
+          # https://downloads.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz.sha512
+          CHECKSUM: a555254d6b53d267965a3404ecb14e53c3827c09c3b94b5678835887ab404556bfaf78dcfe03ba76fa2508649dca8531c74bca4d5846513522404d48e8c4ac8b
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:


### PR DESCRIPTION
This fixes occurrence of 

```
[ERROR] The build could not read 1 project -> [Help 1]
org.apache.maven.project.ProjectBuildingException: Some problems were encountered while processing the POMs:
[ERROR] Unknown packaging: hpi @ io.jenkins.plugins:flyway-api:${revision}-${changelist}, /home/runner/work/flyway-api-plugin/flyway-api-plugin/pom.xml, line 13, column 14
at org.apache.maven.project.DefaultProjectBuilder.build (DefaultProjectBuilder.java:397)
at org.apache.maven.graph.DefaultGraphBuilder.collectProjects (DefaultGraphBuilder.java:414)
```

Seen in https://github.com/jenkinsci/flyway-api-plugin/pull/78/checks for example 

Confirmed this work by running this adapted workflow on https://github.com/jenkinsci/flyway-api-plugin/pull/99/checks

Except the maven version upgrade, the rest remain outouched

Possible caused by recent changes https://github.com/jenkinsci/maven-hpi-plugin ?

I can easily reproduce locally with Maven 3.8.8.