### PR TITLE
Add auto tag updating for major version

### DIFF
--- a/.github/workflows/self-update-major-tag.yml
+++ b/.github/workflows/self-update-major-tag.yml
@@ -1,0 +1,42 @@
+name: Release
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: false
+        description: The tag to move major version tag to
+        default: ""
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: version
+        id: version
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          if [[ "${INPUT_TAG}" =~ ^v[0-9]+.[0-9]+.[0-9]+$ ]]; then
+            tag="${INPUT_TAG}"
+          fi
+          if [[ ! -z "${GITHUB_REF}" ]] && [[ "${GITHUB_REF}" =~ ^refs/tags/v[0-9]+.[0-9]+.[0-9]+$ ]]; then
+            tag=${GITHUB_REF/refs\/tags\//}
+          fi
+          if [[ -z "${tag}" ]]; then
+            echo "No tag found"
+            exit 1
+          fi
+          version=${tag#v}
+          major=${version%%.*}
+          echo "tag=${tag}" >> $GITHUB_OUTPUT
+          echo "version=${version}" >> $GITHUB_OUTPUT
+          echo "major=${major}" >> $GITHUB_OUTPUT
+      - name: force update major tag
+        run: |
+          git tag v${{ steps.version.outputs.major }} ${{ steps.version.outputs.tag }} -f
+          git push origin refs/tags/v${{ steps.version.outputs.major }} -f


### PR DESCRIPTION
Synced from https://github.com/jenkins-infra/github-reusable-workflows/blob/main/.github/workflows/self-update-major-tag.yml