### PR TITLE
Use dlcdn instead of downloads.apache.org

### DIFF
--- a/.github/workflows/jenkins-security-scan.yaml
+++ b/.github/workflows/jenkins-security-scan.yaml
@@ -36,7 +36,7 @@ jobs:
       # https://github.com/jenkins-infra/github-reusable-workflows/issues/36
       - name: Set up Maven
         run: |
-          wget --no-verbose https://downloads.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz
+          wget --no-verbose https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz
           echo $CHECKSUM apache-maven-$MAVEN_VERSION-bin.tar.gz | sha512sum --check
           tar xzf apache-maven-$MAVEN_VERSION-bin.tar.gz
           rm apache-maven-$MAVEN_VERSION-bin.tar.gz


### PR DESCRIPTION
We've been having some reliability issues with this domain, see https://github.com/jenkins-infra/github-reusable-workflows/issues/40

sideport of https://github.com/jenkins-infra/github-reusable-workflows/pull/41