### PR TITLE
Upgrade default Java version to Java 21

### DIFF
--- a/.github/workflows/jenkins-security-scan.yaml
+++ b/.github/workflows/jenkins-security-scan.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: ${{ inputs.java-version || '17' }}
+          java-version: ${{ inputs.java-version || '21' }}
           cache: ${{ inputs.java-cache }}
 
       - name: Initialize CodeQL


### PR DESCRIPTION
Fixes https://github.com/jenkins-infra/jenkins-security-scan/issues/42

I think this should be shipped as a new major release as there is a slight risk of breaking builds since most consumers pull the workflow as `uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2`.